### PR TITLE
Spectator ready up

### DIFF
--- a/promod/readyup.gsc
+++ b/promod/readyup.gsc
@@ -88,9 +88,19 @@ main()
 
 			if ( !player.ready || isDefined( player.inrecmenu ) && player.inrecmenu && !player promod\client::get_config( "PROMOD_RECORD" ) )
 			{
-				level.not_ready_count++;
-				all_players_ready = false;
-				player.update = false;
+				if(player.pers["team"] == "spectator" && level.players.size > 1)
+				{
+					player.update = true;
+					player.pers["record_reminder_done"] = true;
+					player openMenu( game["menu_demo"] );
+					player.inrecmenu = true;
+				}
+				else
+				{
+					level.not_ready_count++;
+					all_players_ready = false;
+					player.update = false;
+				}
 			}
 
 			player.newready = player.update;


### PR DESCRIPTION
Spectators will not get flaged for not ready.

Tested locally alone, should be tested more on other match modes and with more players, but it shoud work like this.
- If player's team is "spectator" he will get flaged as ready 
- Checking are there 2 players before allowing the ready flag to prevent a possible scenario where a first player in the match joins and enteres spectators so he won't start the match.